### PR TITLE
FIX: Don't assume SS3 or SS4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		"name": "Zauberfisch"
 	}],
 	"require": {
-		"silverstripe/framework": ">=2.4",
-		"silverstripe/cms": ">=2.4"
+		"silverstripe/framework": "^2.4",
+		"silverstripe/cms": "^2.4"
 	}
 }


### PR DESCRIPTION
Major versions won't automatically work, and so I've amended the composer requirements
not to allow SS3 or SS4.

This will also ensure that addons.silverstripe.org correctly reports which modules
work with SS3 and SS4.